### PR TITLE
Railway deployment and devcontainer update

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,6 @@
+FROM mcr.microsoft.com/devcontainers/python:3.12
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends bash curl python3-pip libpq5 \
+    && python3 -m pip install --upgrade pip \
+    && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL https://cli.new | bash

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+    "name": "Python 3.12",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "postCreateCommand": "",
+    "customizations": {
+        "vscode": {
+            "settings": {
+                "python.defaultInterpreterPath": "/usr/local/bin/python3"
+            },
+            "extensions": [
+                "ms-python.python"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
# Summary

This PR sets up the codespace for Railway deployment.

Dev deployment URL:  
https://projectpomelo-dev.up.railway.app/  
Service name: `capstone-2510-dev`

Main deployment URL:  
https://projectpomelo-main.up.railway.app/  
https://projectpomelo.com  
Service name: `capstone-2510-main`


The deployment is redeployed on every push to `dev`/`main` branch. I recommend you set up CI tests to ensure that pushes which will cause deployment to fail are blocked.

The devcontainer config has also been refactored to do the following:
- install pip and railway CLI

Using the railway CLI requires `RAILWAY_TOKEN` environment variable. This is set as a codespace secret in the repository, accessible to repo admins only.

## Railway CLI usage

Use these commands in the terminal in the codespace.

**Retrieve deployment logs**
```bash
railway logs --service <service_name>
```

e.g.
```bash
railway logs --service capstone-2510-dev
```

**Get/set environment variables**
```bash
railway variable set --service <service_name> <VARNAME>=<value>
```

e.g.
```bash
railway variable set --service capstone-2510-dev SECRET_KEY=abcde
```

**List environment variables**
```bash
railway variable list --service <service_name>
```

e.g.
```bash
railway variable list --service capstone-2510-dev
```